### PR TITLE
Refactor/skills page

### DIFF
--- a/src/components/FormInfo.js
+++ b/src/components/FormInfo.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export const FormInfo = () => {
+  return (
+    <form>
+      <label></label>
+    </form>  
+  )
+}
+
+

--- a/src/components/InfoField.js
+++ b/src/components/InfoField.js
@@ -1,6 +1,6 @@
 export const InfoField = ({ heading, info }) => {
   return (
-    <article>
+    <article className='info-field'>
       <h2 className="info-heading">{heading}</h2>
       <p className="info-value">{info}</p>
     </article>

--- a/src/components/SkillsPage.js
+++ b/src/components/SkillsPage.js
@@ -57,12 +57,14 @@ export const SkillsPage = () => {
   });
 
   return (
-    <section className="skills-container">
+    <section className="skills-sheet">
       <div className="skill-headings">
-        <h2>Skills</h2>
-        <h2>Ranks</h2>
+        <h2 className='heading'>Skills</h2>
+        <h2 className='heading'>Ranks</h2>
       </div>
+      <article className='skills-container'>
       {skillBars}
+      </article>
     </section>
   );
 }

--- a/src/styles/abstracts/misc.scss
+++ b/src/styles/abstracts/misc.scss
@@ -13,6 +13,7 @@ $border-radius-tertiary: 100%;
 
 $blur-primary: blur(10px);
 $blur-secondary: blur(40px);
+$blur-tertiary: blur(1px);
 
 $text-shadow: 1px 1px 9px $color-transparent-primary;
 $text-stroke: 0.5px $color-accent-primary;

--- a/src/styles/elements/landmarks.scss
+++ b/src/styles/elements/landmarks.scss
@@ -23,7 +23,8 @@ footer {
 }
 
 article {
-  @include flex(column, center)
+  height: 100%;
+  width: 100%;
 }
 
 form {

--- a/src/styles/layout/InfoField.scss
+++ b/src/styles/layout/InfoField.scss
@@ -1,14 +1,16 @@
-.info-heading {
-  @include fonts(medium);
-  width: 90%;
-  text-align: left;
-}
-
-.info-value {
-  color: $color-accent-primary;
-  background-color: $color-primary;
-  border: $border-primary;
-  border-radius: $border-radius-primary;
-  width: 94%;
-  text-align: center;
+.info-field {
+  height: unset;
+  .info-heading {
+    @include fonts(medium);
+    width: 90%;
+    text-align: left;
+  }
+  .info-value {
+    color: $color-accent-primary;
+    background-color: $color-primary;
+    border: $border-primary;
+    border-radius: $border-radius-primary;
+    width: 94%;
+    text-align: center;
+  }
 }

--- a/src/styles/layout/SkillBar.scss
+++ b/src/styles/layout/SkillBar.scss
@@ -2,8 +2,8 @@
   overflow: hidden;
   border: $border-primary;
   border-radius: $border-radius-primary;
-  height: 1.125rem;
   width: 12rem;
+  height: 1.125rem;
   background-image: linear-gradient(
     90deg, 
     $color-white 20%, 

--- a/src/styles/layout/SkillsContainer.scss
+++ b/src/styles/layout/SkillsContainer.scss
@@ -1,9 +1,57 @@
-.skills-container {
-  overflow-y: auto;
-  padding: .25rem;
-}
+.skills-sheet {
+  position: relative;
+  margin-bottom: .2rem;
+  width: 100%;
+  height: 80%;
 
-.skill-headings {
-  @include flex(row, space-between);
-  padding: 0 1.5rem;
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    top: 1rem;
+    width: 100%;
+    height: 22rem;
+    filter: $blur-tertiary;
+    background-image: linear-gradient(to bottom,
+        $color-background-primary 0%,
+        hsla(0, 0%, 0, 0) 40%,
+        hsla(0, 0%, 0, 0) 100%);
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    bottom: -4rem;
+    overflow-y: initial;
+    width: 100%;
+    height: 5rem;
+    filter: $blur-primary;
+    background-image: linear-gradient(to bottom,
+        hsla(0, 0%, 0, 0) 0%,
+        $color-background-primary 10%,
+        $color-background-primary 100%,
+      );
+  }
+
+  .skill-headings {
+    @include flex(row, space-between);
+    position: absolute;
+    width: 100%;
+    padding: 0 2.5rem;
+    .heading {
+      @include fonts(giant, $font-weight-bold);
+      opacity: 1;
+      color: $color-white;
+    }
+  }
+
+  .skills-container {
+    z-index: 0;
+    overflow-y: auto;
+    margin: 3rem 0;
+    width: 100%;
+    height: 100%;
+    padding: 1rem 1rem 0rem;
+  }
 }

--- a/src/styles/layout/SkillsContainer.scss
+++ b/src/styles/layout/SkillsContainer.scss
@@ -23,7 +23,6 @@
     position: absolute;
     z-index: 0;
     bottom: -4rem;
-    overflow-y: initial;
     width: 100%;
     height: 5rem;
     filter: $blur-primary;

--- a/src/styles/layout/SkillsContainer.scss
+++ b/src/styles/layout/SkillsContainer.scss
@@ -14,7 +14,7 @@
     filter: $blur-tertiary;
     background-image: linear-gradient(to bottom,
         $color-background-primary 0%,
-        hsla(0, 0%, 0, 0) 40%,
+        hsla(0, 0%, 0, 0) 35%,
         hsla(0, 0%, 0, 0) 100%);
   }
 
@@ -51,6 +51,6 @@
     margin: 3rem 0;
     width: 100%;
     height: 100%;
-    padding: 1rem 1rem 0rem;
+    padding: 2rem 1rem 3.25rem;
   }
 }

--- a/src/styles/layout/SkillsContainer.scss
+++ b/src/styles/layout/SkillsContainer.scss
@@ -1,4 +1,5 @@
 .skills-container {
+  overflow-y: auto;
   padding: .25rem;
 }
 

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -30,10 +30,10 @@ lV - Layout | Specialized CSS
 ========================================================================== */
 
 @import './layout/Header.scss';
-@import './layout/SkillBar.scss';
-@import './layout/SkillsContainer.scss';
+@import './layout/Characteristic.scss';
+@import './layout/Characteristics.scss';
 @import './layout/InfoField.scss';
 @import './layout/NavBar.scss';
 @import './layout/Orb.scss';
-@import './layout/Characteristics.scss';
-@import './layout/Characteristic.scss';
+@import './layout/SkillBar.scss';
+@import './layout/SkillsContainer.scss';


### PR DESCRIPTION
# Refactor Skills page

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature <!---  non-breaking change which adds functionality -->
- [x] Refactor
- [ ] Bugfix <!---  fix non-breaking change which fixes an issue -->
- [ ] Documentation

## About
This initially was a branch for creating the first character form (which is why the first few commits are relevant to that). However, at some point last night I exploring the application and thought "wouldn't it be cool to use before/after pseudo-elements to blur the skills when the user scrolls up and down?"

## Details
- What problems did this solve? Was it a problem to begin with 😅
- Looking back at the main CSS overhaul, it does not seem like it should've been too complicated but I had issues with the actual before/after elements being overlapped with the `overflow: hidden in the parent element.  It fixed the blur clipping but then it made it so you would have to scroll down to view the navbar which isn't a good user experience. I then fixed it by changing the height from 100% to 80% for the page. 

## Concerns

- Tablet & Desktop view.. a bit concerning considering how hacky some of the CSS has been to get it to look good for mobile view.