### PR TITLE
Feature/global state

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,22 +1,33 @@
-import React from "react";
+import React, { useReducer } from "react";
 import { Route } from "react-router-dom";
 import { Header } from './Header'
 import { SkillsPage } from "./SkillsPage";
 import { CharacterPage } from "./CharacterPage";
 import { NavBar } from "./NavBar";
+import { UserContext } from "../utilities/UserContext";
+import { reducer } from "../utilities/reducer";
+
+const initialState = {
+  isAuthorize: false
+}
 
 export const App = () => {
+  const [state, dispatch] = useReducer(reducer, initialState)
+  
   return (
-    <main>
-      <Header />
-      <Route path="/character">
-        <CharacterPage />
-      </Route>
-      <Route path="/skills">
-        <SkillsPage />
-      </Route>
-      <NavBar />
-    </main>
-  );
+    <UserContext.Provider value={{ state, dispatch }} >      
+      <main>
+        <Header />
+          <Route path="/character">
+            <CharacterPage />
+          </Route>
+          <Route path="/skills">
+            <SkillsPage />
+          </Route>
+        <NavBar />
+      </main>
+    </UserContext.Provider>    
+  )
 }
+
 

--- a/src/components/Orb.js
+++ b/src/components/Orb.js
@@ -1,15 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { NavLink } from 'react-router-dom';
+import { UserContext } from '../utilities/UserContext'
 
 export const Orb = ({ pathway, icon, size }) => {
+  const { state: { isAuthorize }  } = useContext(UserContext)
   const file = icon.substr(14) 
   const iconName = file.substr(0, file.indexOf('.'))
 
   return (
-    <NavLink className={`button  ${size}`} to={pathway} >
+    <>
+    {/* Remove the !-bang operator to disable the hide feature for developement */}
+    <NavLink className={`button ${size} ${!isAuthorize && 'disabled'}`} to={pathway} >
       <img className={`icon ${iconName} ${size}`}  src={icon} alt={`${iconName} icon.`} />
       <div className={`orb ${size}`} />
     </NavLink>
+    </>
   )
 }
 

--- a/src/styles/elements/landmarks.scss
+++ b/src/styles/elements/landmarks.scss
@@ -13,6 +13,7 @@ header {
 main {
   @include flex(column, space-between);
   position: relative;
+  overflow: hidden;
   width: 100vw;
   height: 100vh;
 }

--- a/src/styles/layout/Orb.scss
+++ b/src/styles/layout/Orb.scss
@@ -55,7 +55,7 @@
   
   &.disabled {
     pointer-events: none;
-    transform:translateY(5rem);
+    transform:translateY(10rem);
   }
 }
 

--- a/src/styles/layout/Orb.scss
+++ b/src/styles/layout/Orb.scss
@@ -3,6 +3,7 @@
   position: relative;
   transition: 500ms transform;
   border-radius: $border-radius-tertiary;
+
   &.small:hover,
   &.medium:hover {
     transform: scale(1.2);
@@ -37,6 +38,7 @@
     box-shadow: $box-shadow-primary;
     mix-blend-mode: overlay;
     backdrop-filter: blur(56.1257px);
+
     &.small {
       width: 3rem;
       height: 3.5rem;
@@ -48,8 +50,12 @@
     &.large {
       width: 5rem;
       height: 5rem;
-
     }
+  }
+  
+  &.disabled {
+    pointer-events: none;
+    transform:translateY(5rem);
   }
 }
 

--- a/src/utilities/UserContext.js
+++ b/src/utilities/UserContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react'
+
+export const UserContext = createContext()
+

--- a/src/utilities/reducer.js
+++ b/src/utilities/reducer.js
@@ -1,0 +1,20 @@
+export const reducer = (state, action) => {
+	const { type, isValid } = action
+  switch (type) {
+    case "ACTIVATE":
+      localStorage.setItem("token", JSON.stringify(isValid))
+      return {
+        ...state,
+        isAuthorize: true,
+      };
+    case "AUTOACTIVATE": 
+      const token = JSON.parse(localStorage.getItem('token'))
+      return token ?
+        {
+        ...state,
+        token: token,
+      } : state
+    default:
+    return state
+  }
+};

--- a/src/utilities/reducer.js
+++ b/src/utilities/reducer.js
@@ -12,7 +12,7 @@ export const reducer = (state, action) => {
       return token ?
         {
         ...state,
-        token: token,
+        isAuthorize: token,
       } : state
     default:
     return state


### PR DESCRIPTION
# Add Global State
 
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature <!---  non-breaking change which adds functionality -->
- [ ] Refactor
- [ ] Bugfix <!---  fix non-breaking change which fixes an issue -->
- [ ] Documentation

## About
Add global state via `useContext` and disabled the buttons for when the user is creating a character (to prevent accidental navigation or confusion). There's no logic for what will trigger the state's `isAuthorize` from false to true. Still, the reducer file is set to establish that connection (which I imagine would be the final submit button for the character creation).

## Details
- Add global context for a boolean that should trigger when the navbar's button show
- There's a comment on what you should delete to enable the buttons (let me know if enabling the buttons look cool 😅)
- Add `reduce.js` file.
   - It has a 'login' type thingie that will update state and add a token to the local storage when a character is made
   We'll need to add a `useEffect` to the state, but we can check local storage for a token. If it has one, we can have it do a fetch call to the last character (we will also need to add charID to local storage, but I figure we can do that after the form is done). 

## Concerns

- Maybe Lauren doesn't think the hiding buttons enabling look as cool as I think they do.
