### PR TITLE
Bugfix: Refetch after character creation

### DIFF
--- a/src/components/FormSkills.js
+++ b/src/components/FormSkills.js
@@ -5,6 +5,7 @@ import { useMutation } from '@apollo/client';
 import { FormField } from './FormField';
 
 import { CREATE_DETAILS, CREATE_CHARACTERISTICS, CREATE_SKILLS } from '../graphql/mutations';
+import { ALL_CHARACTERS } from '../graphql/queries';
 import { UserContext } from '../utilities/UserContext';
 
 export const FormSkills = ({ onChange, formState }) => {
@@ -26,6 +27,7 @@ export const FormSkills = ({ onChange, formState }) => {
     onCompleted() {
       history.push('/character');
     },
+    refetchQueries: [{ query: ALL_CHARACTERS }, 'getAllCharacters'],
   });
 
   const [createCharDetails, { loading: detailsLoading, error: detailsError }] = useMutation(CREATE_DETAILS, {

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -1,18 +1,8 @@
 import React from 'react';
 import { Link, Redirect } from 'react-router-dom';
-import { useQuery, gql } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 
-const ALL_CHARACTERS = gql`
-  query getAllCharacters($id: ID!) {
-    user(id: $id) {
-      username
-      characters {
-        id
-        name
-      }
-    }
-  }
-`;
+import { ALL_CHARACTERS } from '../graphql/queries';
 
 export const HomePage = ({ currentUser, setCurrentChar }) => {
   const { loading, error, data } = useQuery(ALL_CHARACTERS, { variables: { id: currentUser } });

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -1,0 +1,13 @@
+import { gql } from '@apollo/client';
+
+export const ALL_CHARACTERS = gql`
+  query getAllCharacters($id: ID!) {
+    user(id: $id) {
+      username
+      characters {
+        id
+        name
+      }
+    }
+  }
+`;


### PR DESCRIPTION
# Refetch data after character creation

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature <!---  non-breaking change which adds functionality -->
- [ ] Refactor
- [x] Bugfix <!---  fix non-breaking change which fixes an issue -->
- [ ] Documentation

## About
<!--- Describe your changes in detail -->
Fixes a bug where newly created characters would not show up on the homepage until refreshing

## Details
<!--- Why is this change required? What problem does it solve? -->
<!--- Or use this as a checklist-->
- Moved the `ALL_CHARACTERS` query into a new file
- Added a `refetchQueries` option to the skills mutation
- Updated the homepage with new query import